### PR TITLE
Convert OUTPUT_DIRECTORY to optional argument with default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ Options:
   -l --log-level=LEVEL              If specified, then the log level will be set to
                                     the specified value.  Valid values are "debug", "info",
                                     "warning", "error", and "critical". [default: info]
+  --output-dir=OUTPUT_DIRECTORY     The directory where the final PDF reports
+                                    should be saved. [default: ~/]
+                         
 Arguments:
   ASSESSMENT_ID                     The assessment identifier.
   ELECTION_NAME                     The name of the election being reported on.
   DOMAIN_TESTED                     The email domain used in the testing.
   JSON_FILE_PATH                    Path to the JSON file to act as a data source.
-  OUTPUT_DIRECTORY                  The directory where the final PDF
-                                    reports should be saved.
 ```
 
 ## Contributing ##

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Options:
   -l --log-level=LEVEL              If specified, then the log level will be set to
                                     the specified value.  Valid values are "debug", "info",
                                     "warning", "error", and "critical". [default: info]
-  --output-dir=OUTPUT_DIRECTORY     The directory where the final PDF reports
+  -o --output-dir=OUTPUT_DIRECTORY  The directory where the final PDF reports
                                     should be saved. [default: ~/]
 
 Arguments:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
                                     "warning", "error", and "critical". [default: info]
   --output-dir=OUTPUT_DIRECTORY     The directory where the final PDF reports
                                     should be saved. [default: ~/]
-                         
+
 Arguments:
   ASSESSMENT_ID                     The assessment identifier.
   ELECTION_NAME                     The name of the election being reported on.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The package collects raw data and creates an encrypted PDF.
 
 ```console
 Usage:
-  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH OUTPUT_DIRECTORY [--log-level=LEVEL]
+  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
 
 Options:
   -h --help                         Show this message.

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -1,7 +1,7 @@
 """cisagov/tpt-reports: A tool for creating Technical Phishing Test (TPT) reports.
 
 Usage:
-  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--output-dir=OUTPUT_DIRECTORY] [--log-level=LEVEL]
+  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
 
 Options:
   -h --help                         Show this message.

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -142,13 +142,13 @@ def main() -> None:
                 error="Possible values for --log-level are "
                 + "debug, info, warning, error, and critical.",
             ),
+            "--output-dir": Use(str, error="--output-dir must be a string."),
+            "ASSESSMENT_ID": Use(str, error="ASSESSMENT_ID must be a string."),
             # Issue #36 - Validate DOMAIN_TESTED argument inputs
             # TODO: Provide input validation for DOMAIN_TESTED.
-            "ASSESSMENT_ID": Use(str, error="ASSESSMENT_ID must be a string."),
-            "ELECTION_NAME": Use(str, error="ELECTION_NAME must be a string."),
             "DOMAIN_TESTED": Use(str, error="DOMAIN_TESTED must be a string."),
+            "ELECTION_NAME": Use(str, error="ELECTION_NAME must be a string."),
             "JSON_FILE_PATH": Use(str, error="JSON_FILE_PATH must be a string."),
-            "--output-dir": Use(str, error="--output-dir must be a string."),
         }
     )
 
@@ -166,12 +166,12 @@ def main() -> None:
         sys.exit(2)
 
     # Assign validated arguments to variables
-    log_level: str = validated_args["--log-level"]
     assessment_id: str = validated_args["ASSESSMENT_ID"]
-    election_name: str = validated_args["ELECTION_NAME"]
     domain_tested: str = validated_args["DOMAIN_TESTED"]
-    output_directory: str = validated_args["--output-dir"]
+    election_name: str = validated_args["ELECTION_NAME"]
     json_file_path: str = validated_args["JSON_FILE_PATH"]
+    log_level: str = validated_args["--log-level"]
+    output_directory: str = validated_args["--output-dir"]
 
     # Set up logging
     logging.basicConfig(

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -1,14 +1,14 @@
 """cisagov/tpt-reports: A tool for creating Technical Phishing Test (TPT) reports.
 
 Usage:
-  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
+  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--output-dir=OUTPUT_DIRECTORY] [--log-level=LEVEL]
 
 Options:
   -h --help                         Show this message.
   -l --log-level=LEVEL              If specified, then the log level will be set to
                                     the specified value.  Valid values are "debug", "info",
                                     "warning", "error", and "critical". [default: info]
-  --output-dir=OUTPUT_DIRECTORY     The directory where the final PDF reports
+  -o --output-dir=OUTPUT_DIRECTORY  The directory where the final PDF reports
                                     should be saved. [default: ~/]
 
 Arguments:

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -1,20 +1,22 @@
 """cisagov/tpt-reports: A tool for creating Technical Phishing Test (TPT) reports.
 
 Usage:
-  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH OUTPUT_DIRECTORY [--log-level=LEVEL]
+  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--output-dir=OUTPUT_DIRECTORY] [--log-level=LEVEL]
 
 Options:
   -h --help                         Show this message.
   -l --log-level=LEVEL              If specified, then the log level will be set to
                                     the specified value.  Valid values are "debug", "info",
                                     "warning", "error", and "critical". [default: info]
+  --output-dir=OUTPUT_DIRECTORY     The directory where the final PDF reports
+                                    should be saved. [default: ~/]
+
 Arguments:
   ASSESSMENT_ID                     The assessment identifier.
   ELECTION_NAME                     The name of the election being reported on.
   DOMAIN_TESTED                     The email domain used in the testing.
   JSON_FILE_PATH                    Path to the JSON file to act as a data source.
-  OUTPUT_DIRECTORY                  The directory where the final PDF
-                                    reports should be saved.
+
 
 """
 
@@ -130,6 +132,7 @@ def generate_reports(
 
 def main() -> None:
     """Load JSON File from supplied argument."""
+    print(sys.argv)
     args: Dict[str, str] = docopt.docopt(__doc__, version=__version__)
     # Validate and convert arguments as needed
     schema: Schema = Schema(
@@ -147,7 +150,7 @@ def main() -> None:
             "ELECTION_NAME": Use(str, error="ELECTION_NAME must be a string."),
             "DOMAIN_TESTED": Use(str, error="DOMAIN_TESTED must be a string."),
             "JSON_FILE_PATH": Use(str, error="JSON_FILE_PATH must be a string."),
-            "OUTPUT_DIRECTORY": Use(str, error="OUTPUT_DIRECTORY must be a string."),
+            "--output-dir": Use(str, error="--output-dir must be a string."),
         }
     )
 
@@ -169,7 +172,7 @@ def main() -> None:
     assessment_id: str = validated_args["ASSESSMENT_ID"]
     election_name: str = validated_args["ELECTION_NAME"]
     domain_tested: str = validated_args["DOMAIN_TESTED"]
-    output_directory: str = validated_args["OUTPUT_DIRECTORY"]
+    output_directory: str = validated_args["--output-dir"]
     json_file_path: str = validated_args["JSON_FILE_PATH"]
 
     # Set up logging
@@ -183,11 +186,11 @@ def main() -> None:
 
     LOGGER.info("Loading TPT Report, Version : %s", __version__)
 
-    # Issue #27 - Input and output file directories change
-    # TODO: Validate that the output_directory is not in the repo.
-    # Create output directory
-    if not os.path.exists(validated_args["OUTPUT_DIRECTORY"]):
-        os.mkdir(validated_args["OUTPUT_DIRECTORY"])
+    # Check if output directory exists and create if needed
+    # output_directory = validated_args.get("OUTPUT_DIRECTORY", "~/")
+    print(output_directory)
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
 
     if generate_reports(
         assessment_id, election_name, domain_tested, output_directory, json_file_path

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -17,7 +17,6 @@ Arguments:
   DOMAIN_TESTED                     The email domain used in the testing.
   JSON_FILE_PATH                    Path to the JSON file to act as a data source.
 
-
 """
 
 
@@ -132,7 +131,6 @@ def generate_reports(
 
 def main() -> None:
     """Load JSON File from supplied argument."""
-    print(sys.argv)
     args: Dict[str, str] = docopt.docopt(__doc__, version=__version__)
     # Validate and convert arguments as needed
     schema: Schema = Schema(
@@ -187,8 +185,6 @@ def main() -> None:
     LOGGER.info("Loading TPT Report, Version : %s", __version__)
 
     # Check if output directory exists and create if needed
-    # output_directory = validated_args.get("OUTPUT_DIRECTORY", "~/")
-    print(output_directory)
     if not os.path.exists(output_directory):
         os.mkdir(output_directory)
 

--- a/tests/test_tpt_reports.py
+++ b/tests/test_tpt_reports.py
@@ -4,7 +4,6 @@
 # Standard Python Libraries
 import logging
 import os
-from re import A
 import sys
 from unittest.mock import patch
 
@@ -194,21 +193,22 @@ def test_no_output_directory(mock_generate_reports):
     with patch.object(sys, "argv", patched_args):
         # Set mock return value
         mock_generate_reports.return_value = True
-        
+
         # Call tpt_reports.main entry poifunction
         result = tpt_reports.tpt_reports.main()
+        assert result is None
 
         # Confirm generate_reports was called once with expected arguments
         expected_call_args = (
-            'test',
-            'test',
-            'test',
+            "test",
+            "test",
+            "test",
             DEFAULT_OUTPUT_DIRECTORY,
-            TEST_JSON_FILE
+            TEST_JSON_FILE,
         )
         assert mock_generate_reports.call_count == 1
         assert mock_generate_reports.call_args[0] == expected_call_args
- 
+
 
 @patch("tpt_reports.tpt_reports.generate_reports")
 def test_with_output_directory(mock_generate_reports):
@@ -220,25 +220,19 @@ def test_with_output_directory(mock_generate_reports):
         "test",
         "test",
         TEST_JSON_FILE,
-        "--output-dir=./"
+        "--output-dir=./",
     ]
-    
+
     # Patch usage arguments
     with patch.object(sys, "argv", patched_args):
         # Set mock return value
         mock_generate_reports.return_value = True
-        
+
         # Call tpt_reports.main entry poifunction
         result = tpt_reports.tpt_reports.main()
- 
+        assert result is None
+
         # Confirm generate_reports was called with expected parameters
-        expected_call_args = (
-            'test',
-            'test',
-            'test',
-            './',
-            TEST_JSON_FILE
-        )
+        expected_call_args = ("test", "test", "test", "./", TEST_JSON_FILE)
         assert mock_generate_reports.call_count == 1
         assert mock_generate_reports.call_args[0] == expected_call_args
- 

--- a/tests/test_tpt_reports.py
+++ b/tests/test_tpt_reports.py
@@ -194,7 +194,7 @@ def test_no_output_directory(mock_generate_reports):
         # Set mock return value
         mock_generate_reports.return_value = True
 
-        # Call tpt_reports.main entry poifunction
+        # Call tpt_reports.main entry point function
         result = tpt_reports.tpt_reports.main()
         assert result is None
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
Resolves #27 and converts OUTPUT_DIRECTORY argument to optional "-o --output-dir" with default value decided by team. The default output directory has been set to "~/" (root of users home directory). This PR also patches generate_reports function in test_tpt_reports.py so that it doesn't actually generate pdfs in unit testing.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##
Closes #27, the result of planning discussions with the team to add versatility to the script and simplicity for users.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Run the command line tool without any output directory supplied to use the default "~/" or pass another directory with --output-dir=<SOME_DIRECTORY>.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--


-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
