### PR TITLE
Update parsing logic to account for recent changes to input JSON file format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The package collects raw data and creates an encrypted PDF.
 
 ```console
 Usage:
-  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
+  tpt-reports ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
 
 Options:
   -h --help                         Show this message.
@@ -31,7 +31,6 @@ Options:
                                     should be saved. [default: ~/]
 
 Arguments:
-  ASSESSMENT_ID                     The assessment identifier.
   ELECTION_NAME                     The name of the election being reported on.
   DOMAIN_TESTED                     The email domain used in the testing.
   JSON_FILE_PATH                    Path to the JSON file to act as a data source.

--- a/src/tpt_reports/_version.py
+++ b/src/tpt_reports/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/tpt_reports/_version.py
+++ b/src/tpt_reports/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.1-rc.1"
+__version__ = "1.1.1"

--- a/src/tpt_reports/_version.py
+++ b/src/tpt_reports/_version.py
@@ -1,2 +1,2 @@
 """This file defines the version of this module."""
-__version__ = "1.1.1"
+__version__ = "1.1.1-rc.1"

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -68,7 +68,6 @@ def parse_json(data):
         if data:
             assessment_id = data["id"]
             for payload in data["phishing_assessment"]["payloads"]:
-                print(payload)
                 num_payloads += 1
                 payload_data = {}
                 payload_data["Payload"] = payload["payload_description"]
@@ -102,7 +101,7 @@ def parse_json(data):
         payloads_meta["num_payloads"] = num_payloads
         payloads_meta["payloads_blocked"] = border_blocked + host_blocked
         payloads_meta["payloads_not_blocked"] = border_not_blocked + host_not_blocked
-        print(payload_data)
+
     except Exception as e:
         LOGGER.exception(str(e))
     return assessment_id, payloads_meta, payloads_list

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -68,6 +68,7 @@ def parse_json(data):
         if data:
             assessment_id = data["id"]
             for payload in data["phishing_assessment"]["payloads"]:
+                print(payload)
                 num_payloads += 1
                 payload_data = {}
                 payload_data["Payload"] = payload["payload_description"]
@@ -101,7 +102,7 @@ def parse_json(data):
         payloads_meta["num_payloads"] = num_payloads
         payloads_meta["payloads_blocked"] = border_blocked + host_blocked
         payloads_meta["payloads_not_blocked"] = border_not_blocked + host_not_blocked
-
+        print(payload_data)
     except Exception as e:
         LOGGER.exception(str(e))
     return assessment_id, payloads_meta, payloads_list

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -71,7 +71,6 @@ def parse_json(data):
                 num_payloads += 1
                 payload_data = {}
                 payload_data["Payload"] = payload["payload_description"]
-                # c2_protocol requires additional space to match input file format
                 payload_data["C2 Protocol"] = payload["c2_protocol"]
 
                 if payload["border_protection"] == "N":

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -66,7 +66,7 @@ def parse_json(data):
     payloads_meta = {}
     try:
         if data:
-            assessment_id = data["id"]
+            assessment_id = data.get("id", "N/A")
             for payload in data["phishing_assessment"]["payloads"]:
                 num_payloads += 1
                 payload_data = {}

--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -1,7 +1,7 @@
 """cisagov/tpt-reports: A tool for creating Technical Phishing Test (TPT) reports.
 
 Usage:
-  tpt-reports ASSESSMENT_ID ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
+  tpt-reports ELECTION_NAME DOMAIN_TESTED JSON_FILE_PATH [--log-level=LEVEL] [--output-dir=OUTPUT_DIRECTORY]
 
 Options:
   -h --help                         Show this message.
@@ -12,7 +12,6 @@ Options:
                                     should be saved. [default: ~/]
 
 Arguments:
-  ASSESSMENT_ID                     The assessment identifier.
   ELECTION_NAME                     The name of the election being reported on.
   DOMAIN_TESTED                     The email domain used in the testing.
   JSON_FILE_PATH                    Path to the JSON file to act as a data source.
@@ -67,12 +66,13 @@ def parse_json(data):
     payloads_meta = {}
     try:
         if data:
-            for payload in data["payloads"]:
+            assessment_id = data["id"]
+            for payload in data["phishing_assessment"]["payloads"]:
                 num_payloads += 1
                 payload_data = {}
                 payload_data["Payload"] = payload["payload_description"]
                 # c2_protocol requires additional space to match input file format
-                payload_data["C2 Protocol"] = payload["c2_protocol "]
+                payload_data["C2 Protocol"] = payload["c2_protocol"]
 
                 if payload["border_protection"] == "N":
                     payload_data["Border Protection"] = "Not Blocked"
@@ -104,27 +104,25 @@ def parse_json(data):
 
     except Exception as e:
         LOGGER.exception(str(e))
-    return payloads_meta, payloads_list
+    return assessment_id, payloads_meta, payloads_list
 
 
-def generate_reports(
-    assessment_id, election_name, domain_tested, output_directory, json_file_path
-):
+def generate_reports(election_name, domain_tested, output_directory, json_file_path):
     """Process steps for generating report data."""
     tpt_info = {}
     tpt_info["domain_tested"] = domain_tested
     tpt_info["election_name"] = election_name
     tpt_info["output_directory"] = output_directory
-    tpt_info["assessment_id"] = assessment_id
 
     data = load_json_file(json_file_path)
     report_status = False
     if data:
-        tpt_info["payloads_meta"], payloads_list = parse_json(data)
+        assessment_id, tpt_info["payloads_meta"], payloads_list = parse_json(data)
         if (
             bool(tpt_info["payloads_meta"]) is not False
             and bool(payloads_list) is not False
         ):
+            tpt_info["assessment_id"] = assessment_id
             logging.debug(tpt_info)
             logging.debug(payloads_list)
             report_gen(tpt_info, payloads_list)
@@ -147,7 +145,6 @@ def main() -> None:
                 + "debug, info, warning, error, and critical.",
             ),
             "--output-dir": Use(str, error="--output-dir must be a string."),
-            "ASSESSMENT_ID": Use(str, error="ASSESSMENT_ID must be a string."),
             # Issue #36 - Validate DOMAIN_TESTED argument inputs
             # TODO: Provide input validation for DOMAIN_TESTED.
             "DOMAIN_TESTED": Use(str, error="DOMAIN_TESTED must be a string."),
@@ -170,7 +167,6 @@ def main() -> None:
         sys.exit(2)
 
     # Assign validated arguments to variables
-    assessment_id: str = validated_args["ASSESSMENT_ID"]
     domain_tested: str = validated_args["DOMAIN_TESTED"]
     election_name: str = validated_args["ELECTION_NAME"]
     json_file_path: str = validated_args["JSON_FILE_PATH"]
@@ -192,12 +188,11 @@ def main() -> None:
     if not os.path.exists(output_directory):
         os.mkdir(output_directory)
 
-    if generate_reports(
-        assessment_id, election_name, domain_tested, output_directory, json_file_path
-    ):
+    if generate_reports(election_name, domain_tested, output_directory, json_file_path):
         LOGGER.info(
-            "TPT report %s was generated successfully in %s.",
-            assessment_id,
+            "TPT report for %s - %s was generated successfully in %s.",
+            election_name,
+            domain_tested,
             output_directory,
         )
 

--- a/tests/data/test.json
+++ b/tests/data/test.json
@@ -1,19 +1,7 @@
 {
-  "asmt_id": "RV####.##",
   "date_generated": "YYYY-M-DD",
   "fiscal_year": 2023,
-  "payloads": [
-    {
-      "border_protection": "N",
-      "c2_protocol ": "c2_1",
-      "code_type": "test_code_type",
-      "command": "test_cmd",
-      "file_types": "test_file_type",
-      "filename": "",
-      "host_protection": "B",
-      "payload_description": "Test payload"
-    }
-  ],
+  "id": "RV####.##",
   "payloads_clean": [
     {
       "Border Protection": "Not Blocked",
@@ -22,6 +10,20 @@
       "Payload": "Test payload"
     }
   ],
+  "phishing_assessment": {
+    "payloads": [
+      {
+        "border_protection": "N",
+        "c2_protocol": "c2_1",
+        "code_type": "test_code_type",
+        "command": "test_cmd",
+        "file_types": "test_file_type",
+        "filename": "",
+        "host_protection": "B",
+        "payload_description": "Test payload"
+      }
+    ]
+  },
   "phishing_assessment_date": "YYYY-M-DD",
   "security_solutions": [
     ""

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -25,7 +25,7 @@ def test_payloads_dataframe():
     """Define a fixture for the payloads DataFrame."""
     with open(TEST_JSON_FILE, encoding="utf-8") as file:
         data = json.load(file)
-        return pd.DataFrame.from_dict(data["payloads"])
+        return pd.DataFrame.from_dict(data["phishing_assessment"]["payloads"])
 
 
 @pytest.fixture

--- a/tests/test_tpt_reports.py
+++ b/tests/test_tpt_reports.py
@@ -79,7 +79,6 @@ def test_log_levels(mock_generate_reports, level):
             "bogus",
             f"--log-level={level}",
             "test",
-            "test",
             "cisa.gov",
             TEST_JSON_FILE,
             "--output-dir=./test_output",
@@ -110,7 +109,7 @@ def test_bad_log_level(mock_generate_reports):
     with patch.object(
         sys,
         "argv",
-        ["bogus", "--log-level=emergency", "test", "test", "test", TEST_JSON_FILE],
+        ["bogus", "--log-level=emergency", "test", "test", TEST_JSON_FILE],
     ):
         return_code = None
         try:
@@ -130,7 +129,6 @@ def test_domain_validation(mock_generate_reports):
             "bogus",
             "--log-level=debug",
             "test",
-            "test",
             "cisa",
             TEST_JSON_FILE,
             "--output-dir=./test_output",
@@ -149,7 +147,7 @@ def test_generate_reports(mock_report_gen):
     """Validate functionality for generate_reports()."""
     mock_report_gen.return_value = True
     return_val = tpt_reports.tpt_reports.generate_reports(
-        "test", "test", "cisa.gov", "./test_output", TEST_JSON_FILE
+        "test", "cisa.gov", "./test_output", TEST_JSON_FILE
     )
     assert return_val is True, "generate_reports() failed to generate a report."
 
@@ -159,7 +157,7 @@ def test_generate_reports_bad_file_name(mock_report_gen):
     """Validate functionality of generate_reports() when a bad filename is provided."""
     mock_report_gen.return_value = False
     return_val = tpt_reports.tpt_reports.generate_reports(
-        "test", "test", "cisa.gov", "./test_output", "nonexistent_file.json"
+        "test", "cisa.gov", "./test_output", "nonexistent_file.json"
     )
     assert (
         return_val is False
@@ -171,7 +169,7 @@ def test_generate_reports_bad_file_data(mock_report_gen):
     """Validate functionality of generate_reports() when bad data is loaded from a file."""
     mock_report_gen.return_value = False
     return_val = tpt_reports.tpt_reports.generate_reports(
-        "test", "test", "cisa.gov", "./test_output", TEST_BAD_JSON_FILE
+        "test", "cisa.gov", "./test_output", TEST_BAD_JSON_FILE
     )
     assert (
         return_val is False
@@ -196,11 +194,13 @@ def test_parse_json():
             "C2 Protocol": "c2_1",
             "Host Protection": "Blocked",
             "Payload": "Test payload",
-        }
+        },
     ]
     data = tpt_reports.tpt_reports.load_json_file(TEST_JSON_FILE)
-    payloads_meta, payloads_list = tpt_reports.tpt_reports.parse_json(data)
-
+    assessment_id, payloads_meta, payloads_list = tpt_reports.tpt_reports.parse_json(
+        data
+    )
+    assert assessment_id == "RV####.##"
     assert payloads_list == payload_list_test
 
     assert payloads_meta["border_blocked"] == 0
@@ -220,7 +220,6 @@ def test_no_output_directory(mock_generate_reports):
         "--log-level=info",
         "test",
         "test",
-        "test",
         TEST_JSON_FILE,
     ]
 
@@ -235,7 +234,6 @@ def test_no_output_directory(mock_generate_reports):
 
         # Confirm generate_reports was called once with expected arguments
         expected_call_args = (
-            "test",
             "test",
             "test",
             DEFAULT_OUTPUT_DIRECTORY,
@@ -253,7 +251,6 @@ def test_with_output_directory(mock_generate_reports):
         "--log-level=info",
         "test",
         "test",
-        "test",
         TEST_JSON_FILE,
         "--output-dir=./",
     ]
@@ -268,6 +265,6 @@ def test_with_output_directory(mock_generate_reports):
         assert result is None
 
         # Confirm generate_reports was called with expected parameters
-        expected_call_args = ("test", "test", "test", "./", TEST_JSON_FILE)
+        expected_call_args = ("test", "test", "./", TEST_JSON_FILE)
         assert mock_generate_reports.call_count == 1
         assert mock_generate_reports.call_args[0] == expected_call_args


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The RPT has updated the format of their JSON data that provides input to TPT-Reports. The source for TPT-Reports has been updated to reflect these changes. The `payloads` list has been nested under the `phishing_assessment` property. In addition, the assessment ID number is provided in the new format, so it is no longer necessary as a command line argument and has been removed. 

All test cases have been updated to reflect these new changes. Resolves issue #66 
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This change is required so the PCA team can use TPT-Reports with the latest RPT JSON format. 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Test cases have been updated and verified with PyTest. 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Revert dependencies to default branches.
- [x] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
