### PR TITLE
Prevent parse_json from crashing on non-object JSON input

### DIFF
--- a/src/tpt_reports/tpt_reports.py
+++ b/src/tpt_reports/tpt_reports.py
@@ -57,6 +57,7 @@ def load_json_file(file_path):
 # TODO: Add unit tests for following logic and remove this comment.
 def parse_json(data):
     """Parse JSON object for values to report."""
+    assessment_id = "N/A"
     border_blocked = 0
     border_not_blocked = 0
     host_blocked = 0

--- a/tests/test_tpt_reports.py
+++ b/tests/test_tpt_reports.py
@@ -68,6 +68,19 @@ def test_release_version():
     ), "RELEASE_TAG does not match the project version"
 
 
+def test_parse_json_non_dict():
+    """Validate parse_json() returns cleanly when the JSON is not an object."""
+    # A JSON file whose top-level value is an array (or any non-object) is
+    # truthy, so generate_reports() passes it through to parse_json(). The
+    # lookups inside then fail, and parse_json() should log the problem and
+    # return defaults rather than raising.
+    assessment_id, payloads_meta, payloads_list = tpt_reports.tpt_reports.parse_json(
+        [1, 2, 3]
+    )
+    assert assessment_id == "N/A"
+    assert payloads_list == []
+
+
 @pytest.mark.parametrize("level", log_levels)
 @patch("tpt_reports.tpt_reports.generate_reports")
 def test_log_levels(mock_generate_reports, level):


### PR DESCRIPTION
Thanks for maintaining this.

I ran into a crash in parse_json() when the source JSON file's top-level value isn't an object. generate_reports() only checks `if data:` before handing the parsed JSON to parse_json(), so a file containing a JSON array (or a bare string/number) clears that guard and reaches the parser.

Inside parse_json(), assessment_id is only assigned in the `if data:` branch, on the same line as the first data.get(...) access. When data is truthy but not a dict, that access raises AttributeError, which the try/except catches and logs, but the final `return assessment_id, ...` then runs with assessment_id never bound and the run dies with UnboundLocalError instead of failing gracefully.

The fix is one line: initialize assessment_id = "N/A" up top with the other accumulators (the same default the function already uses at the data.get("id", "N/A") call). A bad top-level value is now logged and the function returns its defaults, which generate_reports() already treats as "no report".

I also added a small regression test next to the existing tests covering the non-object case.

Before: parse_json([1, 2, 3]) -> UnboundLocalError
After:  parse_json([1, 2, 3]) -> ("N/A", {}, [])

Full suite passes locally with pytest.